### PR TITLE
remove .env.development.local from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ This repo uses docker so setting up is as simple as:
 docker-compose build
 ```
 
-All environment variables that you need are in `.env.development`.  If you need to add sensitive data like a password, add to `.env.development.local` which is ignored by git.
+All environment variables that you need are in `.env.development`.  If you need to add sensitive data like a password, add to `.env.development.local` which is ignored by git. Add to docker-compose.yml like this:
+
+```
+env_file:
+- .env.development
+- .env.development.local
+
+```
+
+
 
 ### Running the application
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - postgres:9.6
     env_file:
       - .env.development
-      - .env.development.local
   postgres:
     image: postgres:latest
     volumes:

--- a/script/boot
+++ b/script/boot
@@ -18,7 +18,7 @@ fi
 docker-compose -f production.yml build client
 docker-compose -f production.yml run --rm client yarn build
 
-docker-compose stop
+docker-compose -f production.yml stop
 docker-compose -f production.yml build api
 docker-compose -f production.yml run --rm api bin/setup
 


### PR DESCRIPTION
Otherwise, a .env.development.local file will be required for local development, when it's really not a requirement.