### PR TITLE
Cleanup after boot

### DIFF
--- a/script/boot
+++ b/script/boot
@@ -4,6 +4,12 @@
 
 set -e
 
+cleanup() {
+  docker system prune -f
+}
+
+trap "cleanup" EXIT
+
 # ensure we're at project root
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 cd "$DIR/.."


### PR DESCRIPTION
There were docker containers lying around that
were taking up memory so yarn build was dying
because it took the memory usage over Digital Ocean
cap.